### PR TITLE
Skip non-GPX files in directory

### DIFF
--- a/stravaplot/plot.py
+++ b/stravaplot/plot.py
@@ -31,7 +31,8 @@ class plot:
         if isfile(strava_path):
             self.strava_data = [strava_path]
         elif isdir(strava_path):
-            self.strava_data = [join(strava_path,f) for f in listdir(strava_path) if isfile(join(strava_path,f))]
+            self.strava_data = [join(strava_path,f) for f in listdir(strava_path) if
+                                f.endswith(".gpx") and isfile(join(strava_path,f))]
         else:
             raise TypeError('Invalid strava data path')
 


### PR DESCRIPTION
I had some non-GPX files (`.fit` files) in my directory:
```python
import stravaplot as strava
s = strava.plot("/tmp/activities/")
s.color("gyroscope")
s.show()
```

Which caused an exception when passing them to `gpxpy`:

```
Traceback (most recent call last):
  File "1.py", line 12, in <module>
    s.show()
  File "/private/tmp/stravaplot/stravaplot/plot.py", line 155, in show
    self._draw()
  File "/private/tmp/stravaplot/stravaplot/plot.py", line 100, in _draw
    gpx = gpxpy.parse(gpx_file)
  File "/usr/local/lib/python3.7/site-packages/gpxpy/__init__.py", line 34, in parse
    parser = mod_parser.GPXParser(xml_or_file)
  File "/usr/local/lib/python3.7/site-packages/gpxpy/parser.py", line 58, in __init__
    self.init(xml_or_file)
  File "/usr/local/lib/python3.7/site-packages/gpxpy/parser.py", line 71, in init
    text = xml_or_file.read() if hasattr(xml_or_file, 'read') else xml_or_file
  File "/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/python3.7/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xeb in position 2: invalid continuation byte
```

Instead, skip files which don't end in `.gpx` when processing a directory.