### PR TITLE
Optimise _deline

### DIFF
--- a/stravaplot/plot.py
+++ b/stravaplot/plot.py
@@ -76,6 +76,8 @@ class plot:
         ax.set_axis_off()
         self.fig.add_axes(ax)
 
+        threshold_squared = self.threshold**2
+
         for f in self.strava_data:
             with open(f) as gpx_file:
                 gpx = gpxpy.parse(gpx_file)
@@ -86,7 +88,7 @@ class plot:
                         for point in segment.points:
                             lat.append(point.latitude)
                             lon.append(point.longitude)
-                    lat,lon = _deline(lat,lon,self.threshold)
+                    lat,lon = _deline(lat,lon,threshold_squared)
                     ax.plot(lon,lat,color=self.linecolor,lw=self.linewidth,alpha=self.linealpha)
 
         self._west,self._east = ax.get_xlim()
@@ -159,7 +161,7 @@ class plot:
 
 
 
-def _deline(lat, lon,threshold):
+def _deline(lat, lon,threshold_squared):
     """ A very simple attempt at removing data collection errors (which appear
     as jumps between locations. Ideally the data will be more appropriately 
     filtered before plotting."""
@@ -172,7 +174,7 @@ def _deline(lat, lon,threshold):
             lon2 = lon[i]
             lon1 = lon[i-1]
             d_squared = (lon2-lon1)**2 + (lat2-lat1)**2
-            if d_squared > threshold**2:
+            if d_squared > threshold_squared:
                 lat.insert(i,np.nan)
                 lon.insert(i,np.nan)
                 i += 2

--- a/stravaplot/plot.py
+++ b/stravaplot/plot.py
@@ -171,8 +171,8 @@ def _deline(lat, lon,threshold):
             lat1 = lat[i-1]
             lon2 = lon[i]
             lon1 = lon[i-1]
-            d = sqrt((lon2-lon1)**2 + (lat2-lat1)**2)
-            if d > threshold:
+            d_squared = (lon2-lon1)**2 + (lat2-lat1)**2
+            if d_squared > threshold**2:
                 lat.insert(i,np.nan)
                 lon.insert(i,np.nan)
                 i += 2


### PR DESCRIPTION
`_deline` is called once for each track in each GPX file.

Because we don't actually need to know the real value of `d`, we can skip calling `sqrt` and instead compare `d**2` with `threshold**2` and get the same result.

`sqrt` is called for each point in each track, and `**2` is quicker than `sqrt`.

Further, `threshold**2` is constant and can be moved outside all these loops.

Some tests. Here's how long (in seconds) it takes to plot and save 732 GPX files with the original, with the first commit in this PR, and with the second commit.

  | Original | no sqrt | threshold_squared
-- | -- | -- | --
First run | 180.81 | 150.65 | 147.01
Second run | 172.08 | 157.82 | 150.74
Third run | 163.19 | 146.81 | 153.24
Average | 172.026667 | 151.76 | 150.33

The 732 files contain 1,155,623 track points, so that's 1,155,623 `sqrt` -> `**2` savings, of about 20 seconds.

That's also 1,155,622 savings of `threshold**2`, of about one second. (I think this effect is probably smaller than that and this is just natural variance, but there's certainly no need to recalculate a constant for each point; it could be at the top of `_deline` as well, meaning it's called once for each track: there are 744 in these 732 files.)

---

`_deline` is very useful, it erases some long lines caused by pausing the GPS tracker when on a train!
